### PR TITLE
Change version of dependency to fix gcc error while installing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ certifi==2017.7.27.1
 chardet==3.0.4
 fusepy==2.0.4
 idna==2.6
-lxml==4.1.0
+lxml==4.5.1
 requests==2.18.4
 urllib3==1.22


### PR DESCRIPTION
On Archlinux I experienced a gcc error while installing the requirements. By changing the version number this error was solved and the fuse worked.